### PR TITLE
Fix job query flow

### DIFF
--- a/HCCGo/app/js/clusterLandingCtrl.js
+++ b/HCCGo/app/js/clusterLandingCtrl.js
@@ -190,9 +190,7 @@ clusterLandingModule.controller('clusterLandingCtrl', ['$scope', '$log', '$timeo
         break;
     }
     $rootScope.clusterInterface = clusterInterface;
-    $rootScope.clusterID = $scope.params.clusterID;
-    getClusterStats($scope.params.clusterId);
-    updateGraphs();
+    $rootScope.clusterId = $scope.params.clusterId;
 
     // Update the cluster every 15 seconds
     var refreshingClusterPromise;

--- a/HCCGo/app/js/jobStatusService.js
+++ b/HCCGo/app/js/jobStatusService.js
@@ -13,6 +13,7 @@ jobStatusService.service('jobStatusService',['$log','$q','notifierService', func
 	var async = require('async');
 	var oldData = null;
 	var lastRequestedTime = 0;
+	var lastPromise = null;
 	return {
 
 	  /**
@@ -26,14 +27,13 @@ jobStatusService.service('jobStatusService',['$log','$q','notifierService', func
      * @returns {Promise} Promise object to be resolved in the controller
      */
 		refreshDatabase: function(db, clusterInterface, clusterId, force=false) {
-			var toReturn = $q.defer();
-
-			// Reloads old data if it's been less than 15 seconds and the user hasn't forced an update
-			if (Date.now() - lastRequestedTime < 15000 && !force){
-				lastRequestedTime = Date.now()
-				toReturn.resolve(oldData);
-			}
-			else {
+			
+			// The lastPromise is a single promise that we will hand out to all requesters
+			// If this is the first run, or if it is time for new data
+			if (lastPromise == null || ((Date.now() - lastRequestedTime > 15000) || force)) {
+				lastPromise = $q.defer();
+			  lastRequestedTime = Date.now();
+				
 			async.parallel([
 
 		      // Query all the uncompleted jobs in the DB
@@ -162,16 +162,14 @@ jobStatusService.service('jobStatusService',['$log','$q','notifierService', func
 		          } else {
 		            updatedData.jobs = recent_completed[0].concat(completed_jobs, cluster_jobs);
 		          }
-
-		          lastRequestedTime = Date.now();
-		          oldData = updatedData;
-		          toReturn.resolve(updatedData);
+							
+		          lastPromise.resolve(updatedData);
 		        });
 		      }
 		    );
 			}
 
-			return toReturn.promise;
+			return lastPromise.promise;
 		}
 	};
 }]);

--- a/HCCGo/app/js/jobSubmissionCtrl.js
+++ b/HCCGo/app/js/jobSubmissionCtrl.js
@@ -203,8 +203,9 @@ jobSubmissionModule.controller('jobSubmissionCtrl', ['$scope', '$log', '$timeout
           }
           submittedJobsDB.insert(doc, function(err, newDoc) {
             if(err) console.log(err);
+            callback(null);
           });
-          callback(null);
+
         }, function(err) {
           callback(new Error("Job submission failed!"))
         });


### PR DESCRIPTION
1. Use a single promise instead of an oldData structure.
2. Make sure that clusterId is spelled correctly.
3. Move callback from within set callback, to make sure data is in the db.